### PR TITLE
Dev

### DIFF
--- a/examples/combined/combined.go
+++ b/examples/combined/combined.go
@@ -31,8 +31,7 @@ func IndexSay(request *types.Request) types.Response {
 
 	body, err := request.Body()
 	if err != nil {
-		// TODO: add WithError to pass directly error
-		return types.WithResponse.WithCode(status.BadRequest)
+		return types.WithResponse.WithError(err)
 	}
 
 	fmt.Println("Somebody said:", strconv.Quote(string(body)))

--- a/http/parser/http1/requestsparser_test.go
+++ b/http/parser/http1/requestsparser_test.go
@@ -21,7 +21,7 @@ var (
 	simpleGET            = []byte("GET / HTTP/1.1\r\n\r\n")
 	simpleGETLeadingCRLF = []byte("\r\n\r\nGET / HTTP/1.1\r\n\r\n")
 	simpleGETAbsPath     = []byte("GET http://www.w3.org/pub/WWW/TheProject.html HTTP/1.1\r\n\r\n")
-	biggerGET            = []byte("GET / HTTP/1.1\r\nHello: World!\r\n\r\n")
+	biggerGET            = []byte("GET / HTTP/1.1\r\nHello: World!\r\nEaster: Egg\r\n\r\n")
 
 	simpleGETQuery = []byte("GET /path?hel+lo=wor+ld HTTP/1.1\r\n\r\n")
 
@@ -76,10 +76,6 @@ func compareRequests(t *testing.T, wanted wantedRequest, actual *types.Request) 
 	}
 }
 
-func copySlice(src []byte) (copied []byte) {
-	return append(copied, src...)
-}
-
 func splitIntoParts(req []byte, n int) (parts [][]byte) {
 	for i := 0; i < len(req); i += n {
 		end := i + n
@@ -87,7 +83,7 @@ func splitIntoParts(req []byte, n int) (parts [][]byte) {
 			end = len(req)
 		}
 
-		parts = append(parts, copySlice(req[i:end]))
+		parts = append(parts, req[i:end])
 	}
 
 	return parts

--- a/http/parser/http1/requestsparserbench_test.go
+++ b/http/parser/http1/requestsparserbench_test.go
@@ -1,0 +1,123 @@
+package http1
+
+import (
+	"testing"
+)
+
+func BenchmarkHttpRequestsParser_Parse_GET(b *testing.B) {
+	parser, _ := getParser()
+
+	// ignoring all the errors because it has to be covered by tests
+
+	simpleGET_1 := splitIntoParts(simpleGET, 1)
+	simpleGET_2 := splitIntoParts(simpleGET, 2)
+	simpleGET_3 := splitIntoParts(simpleGET, 3)
+	simpleGET_5 := splitIntoParts(simpleGET, 5)
+	simpleGET_10 := splitIntoParts(simpleGET, 10)
+
+	testGet := func(b *testing.B, parts [][]byte) {
+		for i := 0; i < b.N; i++ {
+			for part := range parts {
+				_, _, _ = parser.Parse(parts[part])
+			}
+		}
+	}
+
+	b.Run("SimpleGET_1", func(b *testing.B) {
+		testGet(b, simpleGET_1)
+	})
+
+	b.Run("SimpleGET_2", func(b *testing.B) {
+		testGet(b, simpleGET_2)
+	})
+
+	b.Run("SimpleGET_3", func(b *testing.B) {
+		testGet(b, simpleGET_3)
+	})
+
+	b.Run("SimpleGET_5", func(b *testing.B) {
+		testGet(b, simpleGET_5)
+	})
+
+	b.Run("SimpleGET_10", func(b *testing.B) {
+		testGet(b, simpleGET_10)
+	})
+
+	b.Run("SimpleGET_Full", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _, _ = parser.Parse(simpleGET)
+		}
+	})
+
+	biggerGET_1 := splitIntoParts(biggerGET, 1)
+	biggerGET_2 := splitIntoParts(biggerGET, 2)
+	biggerGET_3 := splitIntoParts(biggerGET, 3)
+	biggerGET_5 := splitIntoParts(biggerGET, 5)
+	biggerGET_10 := splitIntoParts(biggerGET, 10)
+
+	b.Run("BiggerGET_1", func(b *testing.B) {
+		testGet(b, biggerGET_1)
+	})
+
+	b.Run("BiggerGET_2", func(b *testing.B) {
+		testGet(b, biggerGET_2)
+	})
+
+	b.Run("BiggerGET_3", func(b *testing.B) {
+		testGet(b, biggerGET_3)
+	})
+
+	b.Run("BiggerGET_5", func(b *testing.B) {
+		testGet(b, biggerGET_5)
+	})
+
+	b.Run("BiggerGET_10", func(b *testing.B) {
+		testGet(b, biggerGET_10)
+	})
+
+	b.Run("BiggerGET_Full", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _, _ = parser.Parse(biggerGET)
+		}
+	})
+
+	manyHeaders := []byte(
+		"GET / HTTP/1.1\r\n" +
+			"Header1: value1\r\n" +
+			"Header2: value2\r\n" +
+			"Header3: value3\r\n" +
+			"ROFL Header: ROFL value\r\n" +
+			"\r\n",
+	)
+	manyHeaders_1 := splitIntoParts(manyHeaders, 1)
+	manyHeaders_2 := splitIntoParts(manyHeaders, 2)
+	manyHeaders_3 := splitIntoParts(manyHeaders, 3)
+	manyHeaders_5 := splitIntoParts(manyHeaders, 5)
+	manyHeaders_10 := splitIntoParts(manyHeaders, 10)
+
+	b.Run("ManyHeaders_1", func(b *testing.B) {
+		testGet(b, manyHeaders_1)
+	})
+
+	b.Run("ManyHeaders_2", func(b *testing.B) {
+		testGet(b, manyHeaders_2)
+	})
+
+	b.Run("ManyHeaders_3", func(b *testing.B) {
+		testGet(b, manyHeaders_3)
+	})
+
+	b.Run("ManyHeaders_5", func(b *testing.B) {
+		testGet(b, manyHeaders_5)
+	})
+
+	b.Run("ManyHeaders_10", func(b *testing.B) {
+		testGet(b, manyHeaders_10)
+	})
+
+	b.Run("ManyHeaders_Full", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _, _ = parser.Parse(manyHeaders)
+		}
+	})
+}

--- a/http/render/renderer.go
+++ b/http/render/renderer.go
@@ -38,14 +38,11 @@ type Renderer struct {
 	defaultHeaders headers.Headers
 }
 
-func NewRenderer(buff []byte) *Renderer {
+func NewRenderer(buff []byte, defaultHeaders headers.Headers) *Renderer {
 	return &Renderer{
-		buff: buff,
+		buff:           buff,
+		defaultHeaders: defaultHeaders,
 	}
-}
-
-func (r *Renderer) SetDefaultHeaders(h headers.Headers) {
-	r.defaultHeaders = h
 }
 
 // Response method is rendering types.Response object into some buffer and then writes

--- a/http/render/rendererbench_test.go
+++ b/http/render/rendererbench_test.go
@@ -1,0 +1,78 @@
+package render
+
+import (
+	"github.com/fakefloordiv/indigo/http/headers"
+	"github.com/fakefloordiv/indigo/http/url"
+	"github.com/fakefloordiv/indigo/settings"
+	"github.com/fakefloordiv/indigo/types"
+	"testing"
+)
+
+func nopWriter(_ []byte) error {
+	return nil
+}
+
+func BenchmarkRenderer_Response(b *testing.B) {
+	buff := make([]byte, 0, 1024)
+	defaultHeadersSmall := headers.Headers{
+		"Server": {"indigo"},
+	}
+	defaultHeadersMedium := headers.Headers{
+		"Server":           {"indigo"},
+		"Connection":       {"keep-alive"},
+		"Accept-Encodings": {"identity"},
+	}
+	defaultHeadersBig := headers.Headers{
+		"Server":           {"indigo"},
+		"Connection":       {"keep-alive"},
+		"Accept-Encodings": {"identity"},
+		"Easter":           {"Egg"},
+		"Multiple":         {"choices", "variants", "ways"},
+		"Something":        {"is not happening"},
+		"Talking":          {"allowed"},
+		"Lorem":            {"ipsum", "doremi"},
+	}
+
+	manager := headers.NewManager(settings.Default().Headers)
+	defaultRequest, _ := types.NewRequest(&manager, url.NewQuery(nil))
+
+	b.Run("DefaultResponse_NoDefHeaders", func(b *testing.B) {
+		renderer := NewRenderer(buff, nil)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			renderer.Response(defaultRequest, types.WithResponse, nopWriter)
+		}
+	})
+
+	b.Run("DefaultResponse_SmallDefHeaders", func(b *testing.B) {
+		renderer := NewRenderer(buff, defaultHeadersSmall)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			renderer.Response(defaultRequest, types.WithResponse, nopWriter)
+		}
+	})
+
+	b.Run("DefaultResponse_MediumDefHeaders", func(b *testing.B) {
+		renderer := NewRenderer(buff, defaultHeadersMedium)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			renderer.Response(defaultRequest, types.WithResponse, nopWriter)
+		}
+	})
+
+	b.Run("DefaultResponse_BigDefHeaders", func(b *testing.B) {
+		renderer := NewRenderer(buff, defaultHeadersBig)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			renderer.Response(defaultRequest, types.WithResponse, nopWriter)
+		}
+	})
+}

--- a/http/render/rendererbench_test.go
+++ b/http/render/rendererbench_test.go
@@ -1,11 +1,12 @@
 package render
 
 import (
+	"testing"
+
 	"github.com/fakefloordiv/indigo/http/headers"
 	"github.com/fakefloordiv/indigo/http/url"
 	"github.com/fakefloordiv/indigo/settings"
 	"github.com/fakefloordiv/indigo/types"
-	"testing"
 )
 
 func nopWriter(_ []byte) error {

--- a/http/server/httpserver.go
+++ b/http/server/httpserver.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"github.com/fakefloordiv/indigo/http/render"
 	"net"
+
+	"github.com/fakefloordiv/indigo/http/render"
 
 	"github.com/fakefloordiv/indigo/http"
 

--- a/http/url/queryparser/parser.go
+++ b/http/url/queryparser/parser.go
@@ -6,6 +6,8 @@ import (
 )
 
 func Parse(data []byte, queryMapFactory func() map[string][]byte) (queries map[string][]byte, err error) {
+	// TODO: make queryMapFactory map[string][]string, just like headers
+
 	var (
 		offset int
 		key    string
@@ -13,6 +15,10 @@ func Parse(data []byte, queryMapFactory func() map[string][]byte) (queries map[s
 
 	state := eKey
 	queries = queryMapFactory()
+
+	if len(data) == 0 {
+		return queries, nil
+	}
 
 	for i := range data {
 		switch state {

--- a/http/url/queryparser/parserbench_test.go
+++ b/http/url/queryparser/parserbench_test.go
@@ -1,0 +1,43 @@
+package queryparser
+
+import "testing"
+
+const initialQueryMapSize = 10
+
+var queriesMap = make(map[string][]byte, initialQueryMapSize)
+
+func BenchmarkParse(b *testing.B) {
+	queriesFactory := func() map[string][]byte {
+		return make(map[string][]byte, initialQueryMapSize)
+	}
+	queriesFactoryNoAlloc := func() map[string][]byte {
+		return queriesMap
+	}
+
+	singlePair := []byte("something=somewhere")
+	manyPairs := []byte("something=somewhere&lorem=ipsum&good=bad&bad=good&paradox=life&dog=cat&cat=dog&life=bad")
+
+	b.Run("SinglePair", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = Parse(singlePair, queriesFactory)
+		}
+	})
+
+	b.Run("ManyPairs", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = Parse(manyPairs, queriesFactory)
+		}
+	})
+
+	b.Run("SinglePairNoAlloc", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = Parse(singlePair, queriesFactoryNoAlloc)
+		}
+	})
+
+	b.Run("ManyPairsNoAlloc", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = Parse(manyPairs, queriesFactoryNoAlloc)
+		}
+	})
+}

--- a/indi.go
+++ b/indi.go
@@ -2,9 +2,10 @@ package indigo
 
 import (
 	"errors"
-	"github.com/fakefloordiv/indigo/http/render"
 	"net"
 	"sync"
+
+	"github.com/fakefloordiv/indigo/http/render"
 
 	"github.com/fakefloordiv/indigo/http/encodings"
 	"github.com/fakefloordiv/indigo/http/headers"

--- a/indi.go
+++ b/indi.go
@@ -2,6 +2,7 @@ package indigo
 
 import (
 	"errors"
+	"github.com/fakefloordiv/indigo/http/render"
 	"net"
 	"sync"
 
@@ -88,7 +89,7 @@ func (a Application) Serve(r router.Router, someSettings ...settings2.Settings) 
 	}
 
 	if onStart, ok := r.(router.OnStart); ok {
-		onStart.OnStart(a.defaultHeaders)
+		onStart.OnStart()
 	}
 
 	settings, err := getSettings(someSettings...)
@@ -115,10 +116,9 @@ func (a Application) Serve(r router.Router, someSettings ...settings2.Settings) 
 			request, gateway, startLineBuff, headerBuff, settings, &headersManager, a.codings,
 		)
 
-		httpServer := server.NewHTTPServer(request, func(b []byte) (err error) {
-			_, err = conn.Write(b)
-			return err
-		}, r, httpParser, conn)
+		renderer := render.NewRenderer(nil, a.defaultHeaders)
+
+		httpServer := server.NewHTTPServer(request, r, httpParser, conn, renderer)
 		go httpServer.Run()
 
 		readBuff := make([]byte, settings.TCPServer.Read.Default)

--- a/router/inbuilt/callbacks.go
+++ b/router/inbuilt/callbacks.go
@@ -2,7 +2,6 @@ package inbuilt
 
 import (
 	"github.com/fakefloordiv/indigo/http"
-	"github.com/fakefloordiv/indigo/http/headers"
 	methods "github.com/fakefloordiv/indigo/http/method"
 	"github.com/fakefloordiv/indigo/types"
 )
@@ -13,17 +12,15 @@ This file contains core-callbacks that are called by server core.
 Methods listed here MUST NOT be called by user ever
 */
 
-// OnStart applies default headers and composes all the registered handlers with middlewares
-// and sets passed default headers from application to renderer
-func (d DefaultRouter) OnStart(defaultHeaders headers.Headers) {
-	d.renderer.SetDefaultHeaders(defaultHeaders)
+// OnStart composes all the registered handlers with middlewares
+func (d DefaultRouter) OnStart() {
 	d.applyGroups()
 	d.applyMiddlewares()
 }
 
 // OnRequest routes the request
-func (d DefaultRouter) OnRequest(request *types.Request, respWriter types.ResponseWriter) error {
-	return d.renderer.Response(request, d.processRequest(request), respWriter)
+func (d DefaultRouter) OnRequest(request *types.Request, render types.Render) error {
+	return render(d.processRequest(request))
 }
 
 func (d DefaultRouter) processRequest(request *types.Request) types.Response {
@@ -53,7 +50,7 @@ func (d DefaultRouter) processRequest(request *types.Request) types.Response {
 }
 
 // OnError receives error and decides, which error handler is better to use in this case
-func (d DefaultRouter) OnError(request *types.Request, respWriter types.ResponseWriter, err error) {
+func (d DefaultRouter) OnError(request *types.Request, render types.Render, err error) {
 	response := d.errHandlers[err](request)
-	_ = d.renderer.Response(request, response, respWriter)
+	_ = render(response)
 }

--- a/router/inbuilt/groups.go
+++ b/router/inbuilt/groups.go
@@ -17,7 +17,6 @@ func (d DefaultRouter) Group(prefix string) *DefaultRouter {
 		middlewares: append(newMiddlewares, d.middlewares...),
 		routes:      make(routesMap),
 		errHandlers: d.errHandlers,
-		renderer:    d.renderer,
 	}
 
 	d.root.groups = append(d.root.groups, *r)

--- a/router/inbuilt/inbuilt.go
+++ b/router/inbuilt/inbuilt.go
@@ -2,7 +2,6 @@ package inbuilt
 
 import (
 	methods "github.com/fakefloordiv/indigo/http/method"
-	"github.com/fakefloordiv/indigo/http/render"
 	"github.com/fakefloordiv/indigo/types"
 )
 
@@ -37,8 +36,6 @@ type DefaultRouter struct {
 
 	routes      routesMap
 	errHandlers errHandlers
-
-	renderer *render.Renderer
 }
 
 // NewRouter constructs a new instance of inbuilt router. Error handlers
@@ -47,8 +44,6 @@ func NewRouter() *DefaultRouter {
 	r := &DefaultRouter{
 		routes:      make(routesMap),
 		errHandlers: newErrHandlers(),
-		// let the first time response be rendered into the nil buffer
-		renderer: render.NewRenderer(nil),
 	}
 
 	r.root = r

--- a/router/inbuilt/inbuiltrouter_middlewares_test.go
+++ b/router/inbuilt/inbuiltrouter_middlewares_test.go
@@ -19,7 +19,7 @@ of specific stuff for testing only middlewares. Decided it's better to
 separate it from all the other tests
 */
 
-func nopRespWriter(_ []byte) error {
+func nopRespWriter(_ types.Response) error {
 	return nil
 }
 
@@ -139,7 +139,7 @@ func TestMiddlewares(t *testing.T) {
 	v2.Get("/world", nopHandler, pointApplied2mware)
 	v2.Use(local3mware)
 
-	r.OnStart(nil)
+	r.OnStart()
 
 	t.Run("/", func(t *testing.T) {
 		request, _ := getRequest()

--- a/router/inbuilt/inbuiltrouter_test.go
+++ b/router/inbuilt/inbuiltrouter_test.go
@@ -117,7 +117,7 @@ func TestGroups(t *testing.T) {
 	v2 := api.Group("/v2")
 	v2.Get("/world", nopHandler)
 
-	r.OnStart(nil)
+	r.OnStart()
 
 	require.Contains(t, r.routes, "/")
 	require.Contains(t, r.routes, "/api/v1/hello")

--- a/router/router.go
+++ b/router/router.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"github.com/fakefloordiv/indigo/http/headers"
 	"github.com/fakefloordiv/indigo/types"
 )
 
@@ -12,12 +11,12 @@ import (
 //         and when you are ready, just notify core that he can safely close
 //         the connection (even if it's already closed from client side)
 type Router interface {
-	OnRequest(request *types.Request, writer types.ResponseWriter) error
-	OnError(request *types.Request, writer types.ResponseWriter, err error)
+	OnRequest(request *types.Request, render types.Render) error
+	OnError(request *types.Request, render types.Render, err error)
 }
 
 // OnStart called when server is initialized and started. Can be implemented
 // optionally
 type OnStart interface {
-	OnStart(defaultHeaders headers.Headers)
+	OnStart()
 }

--- a/router/simple/simple.go
+++ b/router/simple/simple.go
@@ -2,7 +2,6 @@ package simple
 
 import (
 	"github.com/fakefloordiv/indigo/http/encodings"
-	"github.com/fakefloordiv/indigo/http/render"
 	"github.com/fakefloordiv/indigo/http/status"
 	router2 "github.com/fakefloordiv/indigo/router"
 	"github.com/fakefloordiv/indigo/router/inbuilt"
@@ -15,23 +14,21 @@ var defaultErrResponse = types.WithResponse.
 
 // router TODO: add error handler and content encodings setter. Simple does not mean castrated
 type router struct {
-	handler  inbuilt.HandlerFunc
-	renderer *render.Renderer
+	handler inbuilt.HandlerFunc
 }
 
 func NewRouter(handler inbuilt.HandlerFunc) router2.Router {
 	return router{
-		handler:  handler,
-		renderer: render.NewRenderer(nil),
+		handler: handler,
 	}
 }
 
-func (r router) OnRequest(request *types.Request, respWriter types.ResponseWriter) error {
-	return r.renderer.Response(request, r.handler(request), respWriter)
+func (r router) OnRequest(request *types.Request, render types.Render) error {
+	return render(r.handler(request))
 }
 
-func (r router) OnError(request *types.Request, respWriter types.ResponseWriter, _ error) {
-	_ = r.renderer.Response(request, defaultErrResponse, respWriter)
+func (r router) OnError(_ *types.Request, render types.Render, _ error) {
+	_ = render(defaultErrResponse)
 }
 
 func (router) GetContentEncodings() encodings.ContentEncodings {

--- a/router/simple/simple.go
+++ b/router/simple/simple.go
@@ -27,7 +27,7 @@ func (r router) OnRequest(request *types.Request, render types.Render) error {
 	return render(r.handler(request))
 }
 
-func (r router) OnError(_ *types.Request, render types.Render, _ error) {
+func (router) OnError(_ *types.Request, render types.Render, _ error) {
 	_ = render(defaultErrResponse)
 }
 

--- a/types/request.go
+++ b/types/request.go
@@ -85,7 +85,8 @@ func (r *Request) Body() ([]byte, error) {
 	return r.bodyBuff, err
 }
 
-// Reset resets request object. It is made to clear the object between requests
+// Reset resets request headers and reads body into nowhere until completed.
+// It is implemented to clear the request object between requests
 func (r *Request) Reset() error {
 	r.headersManager.Reset()
 	r.Headers = r.headersManager.Headers

--- a/types/response.go
+++ b/types/response.go
@@ -7,7 +7,8 @@ import (
 )
 
 type (
-	ResponseWriter func([]byte) error
+	ResponseWriter func(b []byte) error
+	Render         func(response Response) error
 	FileErrHandler func(err error) Response
 )
 
@@ -85,6 +86,10 @@ func (r Response) WithFile(path string, handler FileErrHandler) Response {
 	r.Filename = path
 	r.handler = handler
 	return r
+}
+
+func (r Response) WithError(err error) Response {
+	return r.WithCode(status.InternalServerError).WithBody(err.Error())
 }
 
 func (r Response) Headers() headers.Headers {


### PR DESCRIPTION
Changelog:
- Added `types.Response.WithError()` method
- Changed routers api: now it does not contain renderers
- Changed internal api: render and default headers are now owned by application instead of router. This fixes problem that renderer is supposed to be per-user, but in reality it was not
  - This also fixes a data race related with response buffer. This fix also increases performance